### PR TITLE
Prevent duplicate row collisions in DuckDB upserts

### DIFF
--- a/test_upsert.py
+++ b/test_upsert.py
@@ -59,4 +59,4 @@ def test_duplicate_ids_do_not_raise(monkeypatch):
     failing_con = FailInsertConnection(con)
     _duckdb_upsert_df(failing_con, 't', df, ['id'])
     rows = con.execute('SELECT * FROM t').fetchall()
-    assert len(rows) == 1 and rows[0][0] == 1
+    assert rows == [(1, 20)]


### PR DESCRIPTION
## Summary
- Deduplicate rows using `SELECT DISTINCT ON` when falling back to manual DuckDB upserts
- Add regression test ensuring duplicate IDs do not trigger `ConstraintException`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0fe6c3048320a48f918ea4408249