### PR TITLE
Add key column validation before deduplication

### DIFF
--- a/tests/test_duckdb_upsert_df.py
+++ b/tests/test_duckdb_upsert_df.py
@@ -23,6 +23,5 @@ def load_duckdb_upsert():
 def test_duckdb_upsert_df_missing_key_raises_value_error():
     _duckdb_upsert_df = load_duckdb_upsert()
     df = pd.DataFrame({'a': [1, 2]})
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Missing key column\(s\) for dummy: b"):
         _duckdb_upsert_df(None, 'dummy', df, ['a', 'b'])
-    assert 'b' in str(excinfo.value)


### PR DESCRIPTION
## Summary
- ensure DuckDB upsert validates that all key columns exist in incoming DataFrames
- add regression test for missing key columns

## Testing
- `python3 -m pytest tests/test_duckdb_upsert_df.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be0fe7e4008320aae0c81e15e165e7