### PR TITLE
Improve error handling for settings load

### DIFF
--- a/qh_api_dashboard.py
+++ b/qh_api_dashboard.py
@@ -10,6 +10,7 @@ import time
 import uuid
 import shutil
 import hashlib
+import logging
 from collections import defaultdict, deque
 from datetime import date, datetime, timezone
 
@@ -23,6 +24,8 @@ from dateutil.relativedelta import relativedelta
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from multiprocessing import get_context
 from streamlit_autorefresh import st_autorefresh
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # 0) Page & CSS
@@ -1189,8 +1192,10 @@ def _duckdb_upsert_df(con, table: str, df: pd.DataFrame, key_cols: list):
         con.execute("DROP TABLE tmp_keys;")
         con.execute("COMMIT;")
     finally:
-        try: con.unregister("df_upsert")
-        except Exception: pass
+        try:
+            con.unregister("df_upsert")
+        except Exception:
+            logger.warning("unregister failed", exc_info=True)
 
 # Settings I/O
 def db_load_settings():
@@ -1201,13 +1206,16 @@ def db_load_settings():
     try:
         _duckdb_init(con)
         row = con.execute("SELECT settings_json FROM app_settings WHERE id=1;").fetchone()
-        if not row or not row[0]: return None
+        if not row or not row[0]:
+            return None
         return json.loads(row[0])
-    except Exception:
+    except (duckdb.Error, json.JSONDecodeError):
         return None
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 def db_save_settings(cfg: dict):
     con = _duckdb_connect()
@@ -1218,8 +1226,10 @@ def db_save_settings(cfg: dict):
         df = pd.DataFrame([{**payload, "id": 1}])
         _duckdb_upsert_df(con, "app_settings", df, ["id"])
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 # =============================================================================
 # 11) Settings UI
@@ -2043,8 +2053,10 @@ def _persist_scale_lookup(con):
         _duckdb_upsert_df(con, "scale_lookup", pd.DataFrame(rows), ["symbol","interval","calc_method"])
 
 def _analyze(con):
-    try: con.execute("PRAGMA analyze;")
-    except Exception: pass
+    try:
+        con.execute("PRAGMA analyze;")
+    except Exception:
+        logger.warning("analyze pragma failed", exc_info=True)
 
 def _export_parquet_mirror(con):
     """Windows-safe Parquet export: short partition columns (mkt, cm, itv) + proper timestamp column."""
@@ -2206,8 +2218,10 @@ def db_fetch_timeseries(symbol: str, interval: str, source: str) -> list:
     except Exception:
         return []
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 def db_upsert_indicators_df(symbol: str, interval: str, source: str, df: pd.DataFrame):
     if df is None or df.empty: return
@@ -2234,8 +2248,10 @@ def db_upsert_indicators_df(symbol: str, interval: str, source: str, df: pd.Data
         _duckdb_init(con)
         _duckdb_upsert_df(con, "indicators", df2, ["symbol","interval","calc_method","time"])
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 def _indicator_warmup_len(cfg: dict) -> int:
     s = cfg.get("indicator_sets", DEFAULT_INDICATOR_SETS)
@@ -2277,8 +2293,10 @@ def _eager_precompute_indicators():
             WHERE "interval" IN ('1D','1H','5M')
         """).df()
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
     if df_active is None or df_active.empty:
         return
     warmup = _indicator_warmup_len(cfg)
@@ -2451,8 +2469,10 @@ def _persist_timeseries_to_db():
         _export_parquet_mirror(con)
 
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
     # External DB snapshot
     _maybe_snapshot_db()
@@ -2487,8 +2507,10 @@ def db_fetch_timeseries_full(symbol: str, interval: str, source: str) -> pd.Data
     except Exception:
         return pd.DataFrame()
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 @st.cache_data(ttl=600, show_spinner=False)
 def db_fetch_indicators_df(symbol: str, interval: str, source: str) -> pd.DataFrame:
@@ -2509,8 +2531,10 @@ def db_fetch_indicators_df(symbol: str, interval: str, source: str) -> pd.DataFr
     except Exception:
         return pd.DataFrame()
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 def _prefer_db(): return bool(cfg.get("prefer_db_display", True))
 def _hard_lock(): return bool(cfg.get("db_hard_lock", True))
@@ -2527,8 +2551,10 @@ def _auto_source_for(sym: str, interval: str):
                 con.close()
                 if c_syn > 0: return "db_syn"
             except Exception:
-                try: con.close()
-                except Exception: pass
+                try:
+                    con.close()
+                except Exception:
+                    logger.warning("close failed", exc_info=True)
     if sym in st.session_state.trusted_api_series.get(interval, set()): return "api"
     if sym in st.session_state.trusted_syn_series.get(interval, set()): return "syn"
     return "api" if sym in st.session_state.series.get(interval, {}) else "syn"
@@ -2578,8 +2604,10 @@ def _status_ts_for_symbol(sym: str):
     except Exception:
         return None
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 def _status_symbol(ts_ms: int):
     if ts_ms is None: return "⚪"
@@ -2740,9 +2768,11 @@ def _build_editor_table(symbols, filters: dict):
                     if row_api: api_1m_val, ts_api = float(row_api[0]), int(row_api[1])
                     if row_syn: syn_1m_val, ts_syn = float(row_syn[0]), int(row_syn[1])
                 except Exception:
-                    pass
-                try: con.close()
-                except Exception: pass
+                    logger.warning("latest value lookup failed", exc_info=True)
+                try:
+                    con.close()
+                except Exception:
+                    logger.warning("close failed", exc_info=True)
             stsym = _status_symbol(max([t for t in [ts_api, ts_syn] if t is not None], default=None))
             row = {
                 "Status": stsym,
@@ -2998,8 +3028,10 @@ def db_fetch_catalog() -> pd.DataFrame:
     except Exception:
         return pd.DataFrame()
     finally:
-        try: con.close()
-        except Exception: pass
+        try:
+            con.close()
+        except Exception:
+            logger.warning("close failed", exc_info=True)
 
 with main_tabs[2]:
     st.markdown("### Contracts Catalog (by Market / Pair)")

--- a/tests/test_db_load_settings.py
+++ b/tests/test_db_load_settings.py
@@ -1,0 +1,81 @@
+import ast
+import types
+import pathlib
+import json
+import pytest
+
+
+def load_subset(tmp_path):
+    code = pathlib.Path('qh_api_dashboard.py').read_text()
+    mod_ast = ast.parse(code)
+    needed = [n for n in mod_ast.body if isinstance(n, ast.FunctionDef) and n.name in ('_duckdb_path', 'db_load_settings')]
+    subset = types.ModuleType('subset')
+    subset.__dict__['os'] = __import__('os')
+    subset.__dict__['json'] = json
+    # minimal ensure_dir
+    subset.ensure_dir = lambda p: __import__('os').makedirs(p, exist_ok=True)
+    # simple session_state
+    class Session(dict):
+        def __getattr__(self, name):
+            return self[name]
+        def __setattr__(self, name, value):
+            self[name] = value
+    subset.st = types.SimpleNamespace(session_state=Session(cfg={'store_root': str(tmp_path), 'db_filename': 'settings.duckdb'},
+                                                            store_root=str(tmp_path)))
+    # placeholders to be patched
+    subset._duckdb_connect = lambda: None
+    subset._duckdb_init = lambda con: None
+    class DuckError(Exception):
+        pass
+    subset.duckdb = types.SimpleNamespace(Error=DuckError)
+    subset.logger = types.SimpleNamespace(warning=lambda *a, **k: None)
+    for fn in needed:
+        exec(compile(ast.Module(body=[fn], type_ignores=[]), 'qh_api_dashboard.py', 'exec'), subset.__dict__)
+    return subset
+
+
+def test_expected_duckdb_error(tmp_path, monkeypatch):
+    mod = load_subset(tmp_path)
+
+    class Conn:
+        def close(self):
+            pass
+    monkeypatch.setattr(mod, '_duckdb_connect', lambda: Conn())
+
+    def bad_init(con):
+        raise mod.duckdb.Error('boom')
+    monkeypatch.setattr(mod, '_duckdb_init', bad_init)
+
+    pathlib.Path(mod._duckdb_path()).touch()
+    assert mod.db_load_settings() is None
+
+
+def test_expected_json_error(tmp_path, monkeypatch):
+    mod = load_subset(tmp_path)
+
+    class Conn:
+        def execute(self, sql):
+            class Cur:
+                def fetchone(self):
+                    return ['not json']
+            return Cur()
+        def close(self):
+            pass
+    monkeypatch.setattr(mod, '_duckdb_connect', lambda: Conn())
+    pathlib.Path(mod._duckdb_path()).touch()
+    assert mod.db_load_settings() is None
+
+
+def test_unexpected_error_propagates(tmp_path, monkeypatch):
+    mod = load_subset(tmp_path)
+
+    class Conn:
+        def close(self):
+            pass
+    monkeypatch.setattr(mod, '_duckdb_connect', lambda: Conn())
+    def boom(con):
+        raise RuntimeError('unexpected')
+    monkeypatch.setattr(mod, '_duckdb_init', boom)
+    pathlib.Path(mod._duckdb_path()).touch()
+    with pytest.raises(RuntimeError):
+        mod.db_load_settings()


### PR DESCRIPTION
## Summary
- log cleanup failures instead of silently passing
- handle only duckdb/json errors in `db_load_settings`
- cover expected vs unexpected errors with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0fe9ee9c8320ab058a26347a4a72