### PR TITLE
Log duplicate removal during DuckDB upsert and add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # API_dashboard
+
+## DuckDB Upsert Utility
+
+The helper `_duckdb_upsert_df` removes duplicate rows based on the provided key columns before inserting into DuckDB. If any duplicates are dropped, the function reports how many rows were removed. Pass `strict=True` to raise an exception if duplicates are detected instead of automatically dropping them.
+


### PR DESCRIPTION
## Summary
- report duplicate rows removed before upserting DataFrames into DuckDB
- add optional `strict` flag to `_duckdb_upsert_df` to raise on duplicates
- document duplicate-handling behavior in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be0feb93d083209fdcc1b3b7334dc8